### PR TITLE
Make a packager's life easy

### DIFF
--- a/pycsa/csa.py
+++ b/pycsa/csa.py
@@ -1,17 +1,16 @@
-
+import os
 import sys
-
-import numpy as np
 import ctypes
 
-import octant
+import numpy as np
+
 
 class CSA(object):
     '''cubic spline approximation for re-gridding 2D data sets
-    
+
     Parameters
     ==========
-    
+
     xin : array-like
         an array of x data point locations
     yin : array-like
@@ -28,23 +27,23 @@ class CSA(object):
         Average number of points per cell (default = 5)
         Decrease to get smaller cells or increase to get larger cells
     npmin : integer
-        Minimal number of points locally involved in spline 
+        Minimal number of points locally involved in spline
         calculation (default = 3)
     npmax : integer
-        Maximum number of points locally involved in spline 
+        Maximum number of points locally involved in spline
         calculation (default = 40)
-        
+
     Returns
     =======
-    
+
     csa_interp : object
         This object can be called with arguments of x and y points to be
         interpolated to.  The input data, zin, can be reset by overwriting
         that object parameter.
-    
+
     Examples
     ========
-    
+
     >>> import csa
     >>> xin = np.random.randn(10000)
     >>> yin = np.random.randn(10000)
@@ -56,49 +55,49 @@ class CSA(object):
     >>> zout = csa_interp(xout, yout)
     >>> import matplotlib.pyplot as plt
     >>> plt.pcolormesh(xout, yout, zout, vmin=-1, vmax=1)
-    >>> plt.scatter(csa_interp.xin, csa_interp.yin, 30, csa_interp.zin, 
+    >>> plt.scatter(csa_interp.xin, csa_interp.yin, 30, csa_interp.zin,
                 edgecolors='k', vmin=-1, vmax=1)
     >>> plt.colorbar()
-    
+
     '''
-    
-    _csa = np.ctypeslib.load_library('_csa', octant.__path__[0])
-    
-    
+
+    csa_path = os.path.join(os.path.dirname(__file__), 'csa')
+    _csa = np.ctypeslib.load_library('_csa', csa_path)
+
     _csa.csa_approximatepoints2.restype = ctypes.POINTER(ctypes.c_double)
-    
-    
+
+
     def __init__(self, xin, yin, zin, sigma=None, npmin=3, npmax=40, k=140, nppc=5):
         self.xin = np.asarray(xin)
         self.yin = np.asarray(yin)
-        
+
         assert xin.size == yin.size, \
             'xin and yin must have the same number of elements'
-        
+
         self._set_zin(zin)
-        
+
         self.sigma = sigma
-        
+
         self.k = k
         self.nppc = nppc
         self.npmin = npmin
         self.npmax = npmax
-        
+
     def _calculate_points(self, xout, yout):
-        
+
         xout = np.asarray(xout)
         yout = np.asarray(yout)
-        
+
         nin = self.xin.size
         nout = xout.size
-        
+
         if self.sigma is None:
             sigma = ctypes.POINTER(ctypes.c_double)()
         else:
             sigma = (ctypes.c_double * nin)(*(self.sigma * np.ones_like(self.xin)))
-        
+
         zout = None
-        
+
         zout = self._csa.csa_approximatepoints2(
                      ctypes.c_int(nin),                        #int nin
                      (ctypes.c_double * nin)(*self.xin.flat),  #double xin[]
@@ -112,56 +111,55 @@ class CSA(object):
                      ctypes.c_int(self.npmax),                 #int npmax
                      ctypes.c_int(self.k),                     #int k
                      ctypes.c_int(self.nppc))                  #int nppc
-        
-        zout = np.asarray([zout[i] for i in range(nout)])  
+
+        zout = np.asarray([zout[i] for i in range(nout)])
         zout.shape = xout.shape
         return np.ma.masked_where(np.isnan(zout), zout)
-    
+
     def __call__(self, xout, yout):
         '''Return interpolated values of zin at locations (xout, yout)'''
         xout = np.asarray(xout)
         yout = np.asarray(yout)
         return self._calculate_points(xout, yout)
-    
+
     def _set_zin(self, zin):
         zin = np.asarray(zin)
         assert zin.size == self.xin.size, \
             'zin must have the same number of elements as xin and yin'
         self._zin = zin
-    
+
     zin = property(lambda self: self._zin, _set_zin, doc='Input values to be approximated')
-    
+
 
 
 if __name__ == '__main__':
     import matplotlib.pyplot as plt
-    
+
     xin = np.random.randn(10000)
     yin = np.random.randn(10000)
     zin = np.sin( xin**2 + yin**2 ) / (xin**2 + yin**2 )
     sigma = 0.01 * np.ones_like(xin)
-    
+
     print ' ### Set up input data points'
-    
+
     xout, yout = np.mgrid[-3:3:100j, -3:3:100j]
-    
+
     csa_interp = CSA(xin, yin, zin)
-    
+
     def plot_csa(csa_interp, xout, yout):
-        
+
         plt.figure()
         zout = csa_interp(xout, yout)
         plt.pcolormesh(xout, yout, zout, vmin=-1, vmax=1)
-        
-        plt.scatter(csa_interp.xin, csa_interp.yin, 10, csa_interp.zin, 
+
+        plt.scatter(csa_interp.xin, csa_interp.yin, 10, csa_interp.zin,
                     edgecolors='none', vmin=-1, vmax=1)
         plt.colorbar()
-    
-    plot_csa(csa_interp, xout, yout)
-    
-    csa_interp.zin = np.cos( xin + yin**2 )
-    
-    plot_csa(csa_interp, xout, yout)
-    
-    plt.show()
 
+    plot_csa(csa_interp, xout, yout)
+
+    csa_interp.zin = np.cos( xin + yin**2 )
+
+    plot_csa(csa_interp, xout, yout)
+
+    plt.show()

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ Python wrapper for csa-c by Pavel Sakov (pavel.sakov@nersc.no):
 
 Based on an algorithm by:
 
-    Haber, J., Zeilfelder, F., Davydov, O., and Seidel, H. P. (2001). 
-    Smooth approximation and rendering of large scattered data sets. 
-    In Proceedings of the conference on Visualization '01, 
+    Haber, J., Zeilfelder, F., Davydov, O., and Seidel, H. P. (2001).
+    Smooth approximation and rendering of large scattered data sets.
+    In Proceedings of the conference on Visualization '01,
     pages 341-348. IEEE Computer Society.
 
 Python wrapper by Robert Hetland (hetland@tamu.edu)
@@ -68,8 +68,7 @@ if __name__ == '__main__':
           packages = ['pycsa'],
           license = 'MIT',
           platforms = ["any"],
-          ext_package='csa',
+          ext_package='pycsa/csa',
           ext_modules = [csa],
           classifiers = filter(None, classifiers.split("\n")),
           )
-    


### PR DESCRIPTION
I removed the references to `octant` and packaged `_csa.so` as a submodule.  This PR allows this module to be installed without octant and keep everything in a `pycsa` module instead of `pycsa` and `csa`.  (The latter was conflicting with [csa](https://pypi.python.org/pypi/csa) when both are installed.)

PS: Sorry for the white space diff noise.
